### PR TITLE
Correcting href link

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,7 +634,7 @@ var TxtType = function(el, toRotate, period) {
 					   </div>
 
 			         <div class="link-box">
-			            <a href="ttps://www.github.com/deep5050/deep-scraping-python">Details</a>
+			            <a href="https://www.github.com/deep5050/deep-scraping-python">Details</a>
 					      <a href="#" class="popup-modal-dismiss">Close</a>
 			         </div>		      
 


### PR DESCRIPTION
Href link used in one of your projects pointing to `ttps://`, correcting this to `https://`